### PR TITLE
Test case for switch case default to improve coverage

### DIFF
--- a/src/math/ordinal.pipe.spec.ts
+++ b/src/math/ordinal.pipe.spec.ts
@@ -47,4 +47,8 @@ describe('OrdinalPipe', () => {
         expect(pipe.transform('a')).toEqual('NaN');
     });
 
+    it('Should return 35th', () => {
+        expect(pipe.transform(35)).toEqual('35th');
+    });
+
 });


### PR DESCRIPTION
Hi @christopheelkhoury, 

After checking the [coveralls report](https://coveralls.io/builds/20802074/source?filename=src%2Fmath%2Fordinal.pipe.ts#L28) from your updated PR (fknop#84), it seems that we were missing a test case for the default statement on the switch construct, which is what was causing the test coverage to drop. I have added one for 35, which should improve the coverage.